### PR TITLE
Improve Version Filter

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -95,8 +95,8 @@ const newPattern = / ?is:(new)/gi;
 const resultsFoundText = "result(s) found";
 
 function versionCompare(base, target) { // Return -1, 0, 1
-  let baseMatches = versionComparePattern.exec(base);
-  let targetMatches = versionComparePattern.exec(target);
+  const baseMatches = versionComparePattern.exec(base);
+  const targetMatches = versionComparePattern.exec(target);
 
   if (baseMatches === null || targetMatches === null) // unknown version, assume old!
     return -1;
@@ -259,7 +259,7 @@ function searchNow(value = "") {
       // Version check
       let versionFound;
       if (version !== "") {
-        let versions = document.querySelectorAll(`#${e.id} .item-details:nth-child(2) td:nth-child(2)`)[0].textContent.split(",");
+        const versions = document.querySelectorAll(`#${e.id} .item-details:nth-child(2) td:nth-child(2)`)[0].textContent.split(",");
         for (const v in versions) {
           let result = versionCompare(version, versions[v]);
           if (versionAndUp) {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -229,6 +229,9 @@ function searchNow(value = "") {
     }
     searchValue = searchValue.replaceAll(versionPattern, "") // Don't include filters in the search
   }
+  let versionArr = null;
+  if (version !== "")
+    versionArr = versionParse(version);
 
   // Type
   let filterType;
@@ -260,9 +263,6 @@ function searchNow(value = "") {
 
       // Version check
       let versionFound;
-      let versionArr = null;
-      if (version !== "")
-        versionArr = versionParse(version);
       if (versionArr !== null) { // if we parsed a version
         const versions = document.querySelectorAll(`#${e.id} .item-details:nth-child(2) td:nth-child(2)`)[0].innerHTML.split(/,|<br\/?>/i);
         for (const v of versions) {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,4 +1,4 @@
-const siteVersion = "2.2.0"; // site version is different from skript version
+const siteVersion = "2.3.0"; // site version is different from skript version
 const ghAPI = "https://api.github.com/repos/SkriptLang/Skript";
 
 // ID Scroll

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -89,7 +89,7 @@ document.querySelectorAll(".new-element").forEach((e) => {
 
 // <> Search Bar
 const versionComparePattern = /.*?(\d+).(\d+)(?:.(\d+))?.*/i;
-const versionPattern = / ?v(?:ersion|):(\d+.\d+(?:.\d+)?)(?:-[^+-]+)?([+-])?/gi;
+const versionPattern = / ?v(?:ersion|):(\d+.\d+(?:.\d+)?)(?:-[^\s+-]+)?([+-])?/gi;
 const typePattern = / ?t(?:ype|):(\w+)/gi;
 const newPattern = / ?is:(new)/gi;
 const resultsFoundText = "result(s) found";

--- a/docs/templates/js/main.js
+++ b/docs/templates/js/main.js
@@ -95,8 +95,8 @@ const newPattern = / ?is:(new)/gi;
 const resultsFoundText = "result(s) found";
 
 function versionCompare(base, target) { // Return -1, 0, 1
-  let baseMatches = versionComparePattern.exec(base);
-  let targetMatches = versionComparePattern.exec(target);
+  const baseMatches = versionComparePattern.exec(base);
+  const targetMatches = versionComparePattern.exec(target);
 
   if (baseMatches === null || targetMatches === null) // unknown version, assume old!
     return -1;
@@ -259,7 +259,7 @@ function searchNow(value = "") {
       // Version check
       let versionFound;
       if (version !== "") {
-        let versions = document.querySelectorAll(`#${e.id} .item-details:nth-child(2) td:nth-child(2)`)[0].textContent.split(",");
+        const versions = document.querySelectorAll(`#${e.id} .item-details:nth-child(2) td:nth-child(2)`)[0].textContent.split(",");
         for (const v in versions) {
           let result = versionCompare(version, versions[v]);
           if (versionAndUp) {

--- a/docs/templates/js/main.js
+++ b/docs/templates/js/main.js
@@ -229,6 +229,9 @@ function searchNow(value = "") {
     }
     searchValue = searchValue.replaceAll(versionPattern, "") // Don't include filters in the search
   }
+  let versionArr = null;
+  if (version !== "")
+    versionArr = versionParse(version);
 
   // Type
   let filterType;
@@ -260,9 +263,6 @@ function searchNow(value = "") {
 
       // Version check
       let versionFound;
-      let versionArr = null;
-      if (version !== "")
-        versionArr = versionParse(version);
       if (versionArr !== null) { // if we parsed a version
         const versions = document.querySelectorAll(`#${e.id} .item-details:nth-child(2) td:nth-child(2)`)[0].innerHTML.split(/,|<br\/?>/i);
         for (const v of versions) {

--- a/docs/templates/js/main.js
+++ b/docs/templates/js/main.js
@@ -1,4 +1,4 @@
-const siteVersion = "2.2.0"; // site version is different from skript version
+const siteVersion = "2.3.0"; // site version is different from skript version
 const ghAPI = "https://api.github.com/repos/SkriptLang/Skript";
 
 // ID Scroll

--- a/docs/templates/js/main.js
+++ b/docs/templates/js/main.js
@@ -89,7 +89,7 @@ document.querySelectorAll(".new-element").forEach((e) => {
 
 // <> Search Bar
 const versionComparePattern = /.*?(\d+).(\d+)(?:.(\d+))?.*/i;
-const versionPattern = / ?v(?:ersion|):(\d+.\d+(?:.\d+)?)(?:-[^+-]+)?([+-])?/gi;
+const versionPattern = / ?v(?:ersion|):(\d+.\d+(?:.\d+)?)(?:-[^\s+-]+)?([+-])?/gi;
 const typePattern = / ?t(?:ype|):(\w+)/gi;
 const newPattern = / ?is:(new)/gi;
 const resultsFoundText = "result(s) found";


### PR DESCRIPTION
This PR aims to improve the version filter, which currently does **not** work for `2.10` (it is interpreted as `2.1` due to the regular expression used). I have gone ahead and applied my changes to the current live version as well. Local tests showed a much-improved result.

Additionally, I have fixed the issue where `-pre` versions are showing up in the `New` page version selector.

Finally, the `-` option for versions now excludes the version itself. That is, `version:2.10.0-` will match all syntax with a `Since` tag mentioning a version below `2.10.0`.

Bumps site version to 2.3.0